### PR TITLE
docs: add Calypso PKI lib, update components version and fix maven central URL

### DIFF
--- a/.github/scripts/changelog_repos.list
+++ b/.github/scripts/changelog_repos.list
@@ -1,4 +1,5 @@
 eclipse-keyple keyple-card-calypso-crypto-legacysam-java-lib
+eclipse-keyple keyple-card-calypso-crypto-pki-java-lib
 eclipse-keyple keyple-card-calypso-java-lib
 eclipse-keyple keyple-card-generic-java-lib
 eclipse-keyple keyple-common-java-api

--- a/.github/scripts/dashboard_check_repos_status.sh
+++ b/.github/scripts/dashboard_check_repos_status.sh
@@ -13,6 +13,10 @@ fi
 if [ $? -eq 0 ]; then
   exit 0
 fi
+./.github/scripts/dashboard_check_repos_status_curl.sh $token eclipse-keyple keyple-card-calypso-crypto-pki-java-lib
+if [ $? -eq 0 ]; then
+  exit 0
+fi
 ./.github/scripts/dashboard_check_repos_status_curl.sh $token eclipse-keyple keyple-card-generic-java-lib
 if [ $? -eq 0 ]; then
   exit 0

--- a/.github/scripts/dashboard_update_repos.sh
+++ b/.github/scripts/dashboard_update_repos.sh
@@ -12,6 +12,8 @@ echo "[" >> dashboard/repository_list.json
 echo "," >> dashboard/repository_list.json
 ../.github/scripts/dashboard_update_repo.sh $token eclipse-keyple keyple-card-calypso-crypto-legacysam-java-lib main true true
 echo "," >> dashboard/repository_list.json
+../.github/scripts/dashboard_update_repo.sh $token eclipse-keyple keyple-card-calypso-crypto-pki-java-lib main true true
+echo "," >> dashboard/repository_list.json
 ../.github/scripts/dashboard_update_repo.sh $token eclipse-keyple keyple-card-generic-java-lib main true true
 echo "," >> dashboard/repository_list.json
 ../.github/scripts/dashboard_update_repo.sh $token eclipse-keyple keyple-common-java-api main true true

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -27,6 +27,7 @@ const ComponentName = {
     DISTRIBUTED_REMOTE_LIB: "distributedRemoteLib",
     CALYPSO_CARD_LIB: "calypsoCardLib",
     CALYPSO_LEGACY_SAM_LIB: "calypsoLegacySamLib",
+    CALYPSO_PKI_LIB: "calypsoPkiLib",
     GENERIC_LIB: "genericLib",
     PLUGIN_ANDROID_NFC_LIB: "pluginAndroidNfcLib",
     PLUGIN_ANDROID_OMAPI_LIB: "pluginAndroidOmapiLib",
@@ -53,6 +54,7 @@ const componentNames = [
     ComponentName.DISTRIBUTED_REMOTE_LIB,
     ComponentName.CALYPSO_CARD_LIB,
     ComponentName.CALYPSO_LEGACY_SAM_LIB,
+    ComponentName.CALYPSO_PKI_LIB,
     ComponentName.GENERIC_LIB,
     ComponentName.PLUGIN_ANDROID_NFC_LIB,
     ComponentName.PLUGIN_ANDROID_OMAPI_LIB,
@@ -74,6 +76,13 @@ function ReleaseTrain (...releases) {
  *****************************************************************************/
 let releaseTrains = [];
 releaseTrains.push(new ReleaseTrain(
+    new Release(ComponentName.CALYPSO_PKI_LIB, "0.2.0")
+));
+releaseTrains.push(new ReleaseTrain(
+    new Release(ComponentName.CALYPSO_LEGACY_SAM_API, "0.6.+"),
+    new Release(ComponentName.CALYPSO_LEGACY_SAM_LIB, "0.7.0")
+));
+releaseTrains.push(new ReleaseTrain(
     new Release(ComponentName.CARD_API, "2.0.1+"),
     new Release(ComponentName.CALYPSO_API, "2.1.+"),
     new Release(ComponentName.CALYPSO_LEGACY_SAM_API, "0.5.+"),
@@ -87,6 +96,7 @@ releaseTrains.push(new ReleaseTrain(
     new Release(ComponentName.DISTRIBUTED_REMOTE_LIB, "2.3.1"),
     new Release(ComponentName.CALYPSO_CARD_LIB, "3.1.1"),
     new Release(ComponentName.CALYPSO_LEGACY_SAM_LIB, "0.6.0"),
+    new Release(ComponentName.CALYPSO_PKI_LIB, "0.1.0"),
     new Release(ComponentName.GENERIC_LIB, "3.0.1"),
     new Release(ComponentName.PLUGIN_ANDROID_NFC_LIB, "2.2.0"),
     new Release(ComponentName.PLUGIN_ANDROID_OMAPI_LIB, "2.1.0"),
@@ -389,6 +399,9 @@ computeAppContent = function(language) {
     }
     if (appDependencies.has("cardCalypsoLegacySam")) {
         contentHtml += "\n" + $(tagPrefix+'keyple-card-calypso-crypto-legacysam-java-lib').html();
+    }
+    if (appDependencies.has("cardCalypsoPki")) {
+        contentHtml += "\n" + $(tagPrefix+'keyple-card-calypso-crypto-pki-java-lib').html();
     }
     if (appDependencies.has("pluginAndroidNfc")) {
         contentHtml += "\n" + $(tagPrefix+'keyple-plugin-android-nfc-java-lib').html();

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -171,7 +171,7 @@ keyple_version:
   keypop_reader_java_api: '2.0.1'
   keypop_card_java_api: '2.0.1'
   keypop_calypso_card_java_api: '2.1.0'
-  keypop_calypso_crypto_legacysam_java_api: '0.5.0'
+  keypop_calypso_crypto_legacysam_java_api: '0.6.0'
 
   keyple_common_java_api: '2.0.1'
   keyple_util_java_lib: '2.4.0'
@@ -180,7 +180,8 @@ keyple_version:
   keyple_service_resource_java_lib: '3.0.1'
 
   keyple_card_calypso_java_lib: '3.1.1'
-  keyple_card_calypso_crypto_legacysam_java_lib: '0.6.0'
+  keyple_card_calypso_crypto_legacysam_java_lib: '0.7.0'
+  keyple_card_calypso_crypto_pki_java_lib: '0.2.0'
   keyple_card_generic_java_lib: '3.0.1'
 
   keyple_plugin_java_api: '2.3.1'

--- a/content/archives/components-java-1.0/core/_index.md
+++ b/content/archives/components-java-1.0/core/_index.md
@@ -52,4 +52,4 @@ implementation 'org.eclipse.keyple:keyple-java-core:{{% keyple-java-version %}}'
 </dependency>
 ```
 
-* Direct [download](https://central.sonatype.dev/search?q=keyple-java-core)
+* Direct [download](https://central.sonatype.com/search?q=keyple-java-core)

--- a/content/archives/components-java-1.0/distributed-systems/local.md
+++ b/content/archives/components-java-1.0/distributed-systems/local.md
@@ -57,4 +57,4 @@ implementation 'org.eclipse.keyple:keyple-java-distributed-local:{{% keyple-java
 </dependency>
 ```
 
-* Direct [download](https://central.sonatype.dev/search?q=keyple-java-distributed-local)
+* Direct [download](https://central.sonatype.com/search?q=keyple-java-distributed-local)

--- a/content/archives/components-java-1.0/distributed-systems/network.md
+++ b/content/archives/components-java-1.0/distributed-systems/network.md
@@ -55,4 +55,4 @@ implementation 'org.eclipse.keyple:keyple-java-distributed-network:{{% keyple-ja
 </dependency>
 ```
 
-* Direct [download](https://central.sonatype.dev/search?q=keyple-java-distributed-network)
+* Direct [download](https://central.sonatype.com/search?q=keyple-java-distributed-network)

--- a/content/archives/components-java-1.0/distributed-systems/remote.md
+++ b/content/archives/components-java-1.0/distributed-systems/remote.md
@@ -57,4 +57,4 @@ implementation 'org.eclipse.keyple:keyple-java-distributed-remote:{{% keyple-jav
 </dependency>
 ```
 
-* Direct [download](https://central.sonatype.dev/search?q=keyple-java-distributed-remote)
+* Direct [download](https://central.sonatype.com/search?q=keyple-java-distributed-remote)

--- a/content/archives/components-java-1.0/extensions/calypso.md
+++ b/content/archives/components-java-1.0/extensions/calypso.md
@@ -53,4 +53,4 @@ implementation 'org.eclipse.keyple:keyple-java-calypso:{{% keyple-java-version %
 </dependency>
 ```
 
-* Direct [download](https://central.sonatype.dev/search?q=keyple-java-calypso)
+* Direct [download](https://central.sonatype.com/search?q=keyple-java-calypso)

--- a/content/archives/components-java-1.0/plugins/nfc.md
+++ b/content/archives/components-java-1.0/plugins/nfc.md
@@ -53,4 +53,4 @@ implementation 'org.eclipse.keyple:keyple-android-plugin-nfc:{{% keyple-java-ver
 </dependency>
 ```
 
-* Direct [download](https://central.sonatype.dev/search?q=keyple-android-plugin-nfc)
+* Direct [download](https://central.sonatype.com/search?q=keyple-android-plugin-nfc)

--- a/content/archives/components-java-1.0/plugins/omapi.md
+++ b/content/archives/components-java-1.0/plugins/omapi.md
@@ -56,4 +56,4 @@ implementation 'org.eclipse.keyple:keyple-android-plugin-omapi:{{% keyple-java-v
 </dependency>
 ```
 
-* Direct [download](https://central.sonatype.dev/search?q=keyple-android-plugin-omapi)
+* Direct [download](https://central.sonatype.com/search?q=keyple-android-plugin-omapi)

--- a/content/archives/components-java-1.0/plugins/pcsc.md
+++ b/content/archives/components-java-1.0/plugins/pcsc.md
@@ -53,4 +53,4 @@ implementation 'org.eclipse.keyple:keyple-java-plugin-pcsc:{{% keyple-java-versi
 </dependency>
 ```
 
-* Direct [download](https://central.sonatype.dev/search?q=keyple-java-plugin-pcsc)
+* Direct [download](https://central.sonatype.com/search?q=keyple-java-plugin-pcsc)

--- a/content/archives/components-java-1.0/plugins/stub.md
+++ b/content/archives/components-java-1.0/plugins/stub.md
@@ -53,4 +53,4 @@ implementation 'org.eclipse.keyple:keyple-java-plugin-stub:{{% keyple-java-versi
 </dependency>
 ```
 
-* Direct [download](https://central.sonatype.dev/search?q=keyple-java-plugin-stub)
+* Direct [download](https://central.sonatype.com/search?q=keyple-java-plugin-stub)

--- a/content/components/card-extensions/keyple-card-calypso-crypto-legacysam-lib.md
+++ b/content/components/card-extensions/keyple-card-calypso-crypto-legacysam-lib.md
@@ -35,7 +35,7 @@ Therefore, it should be used only by application developers.
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-card-calypso-crypto-legacysam-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-card-calypso-crypto-legacysam-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/card-extensions/keyple-card-calypso-crypto-pki-lib.md
+++ b/content/components/card-extensions/keyple-card-calypso-crypto-pki-lib.md
@@ -1,0 +1,52 @@
+---
+title: Keyple Card Calypso Crypto PKI Library
+linktitle: Calypso PKI
+summary: Add-on to enable Calypso® PKI card transactions.
+type: book
+toc: true
+---
+
+{{% callout warning %}}
+This library is currently in **Beta** version.
+While it's nearly stable, future migration steps might be necessary. We aim to minimize any changes you'll need to make.
+{{% /callout %}}
+
+<br>
+
+The **Keyple Card Calypso Crypto PKI Library** is an add-on to enable Calypso® PKI card transactions.
+
+Therefore, it should be used only by application developers.
+
+<br>
+
+## Java component
+
+{{% callout note %}}
+**`{{% keyple-card-calypso-crypto-pki-java-lib-version %}}`**
+<span class="component-metadata">{{< icon name="download" pack="fas" >}} [Download](#download)</span>
+<span class="component-metadata">{{< icon name="github" pack="fab" >}} [GitHub](https://github.com/eclipse-keyple/keyple-card-calypso-crypto-pki-java-lib/)</span>
+<span class="component-metadata">{{< icon name="exchange-alt" pack="fas" >}} [Changelog](https://github.com/eclipse-keyple/keyple-card-calypso-crypto-pki-java-lib/blob/main/CHANGELOG.md)</span>
+{{% /callout %}}
+
+### Documentation
+
+* [API documentation](https://eclipse-keyple.github.io/keyple-card-calypso-crypto-pki-java-lib)
+
+### Download
+
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-card-calypso-crypto-pki-java-lib) or by using one of the project resource managers below:
+
+{{< tabpane >}}
+{{< tab header="Gradle Groovy" lang="gradle" >}}
+implementation 'org.eclipse.keyple:keyple-card-calypso-crypto-pki-java-lib:{{% keyple-card-calypso-crypto-pki-java-lib-version %}}'
+{{< /tab >}}
+{{< tab header="Gradle Kotlin" lang="kotlin" >}}
+implementation("org.eclipse.keyple:keyple-card-calypso-crypto-pki-java-lib:{{% keyple-card-calypso-crypto-pki-java-lib-version %}}"){{< /tab >}}
+{{< tab header="Maven" lang="xml" >}}
+<dependency>
+  <groupId>org.eclipse.keyple</groupId>
+  <artifactId>keyple-card-calypso-crypto-pki-java-lib</artifactId>
+  <version>{{% keyple-card-calypso-crypto-pki-java-lib-version %}}</version>
+</dependency>
+{{< /tab >}}
+{{< /tabpane >}}

--- a/content/components/card-extensions/keyple-card-calypso-lib.md
+++ b/content/components/card-extensions/keyple-card-calypso-lib.md
@@ -36,7 +36,7 @@ At present, only the [Calypso Crypto Legacy SAM]({{< relref "keyple-card-calypso
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-card-calypso-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-card-calypso-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/card-extensions/keyple-card-generic-lib.md
+++ b/content/components/card-extensions/keyple-card-generic-lib.md
@@ -29,7 +29,7 @@ Therefore, it should be used only by application developers.
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-card-generic-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-card-generic-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/core/keyple-common-api.md
+++ b/content/components/core/keyple-common-api.md
@@ -34,7 +34,7 @@ The third version number (x.y.**z**) only concerns updates of the public API doc
  
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-common-java-api) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-common-java-api) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/core/keyple-distributed-local-api.md
+++ b/content/components/core/keyple-distributed-local-api.md
@@ -33,7 +33,7 @@ The third version number (x.y.**z**) only concerns updates of the public API doc
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-distributed-local-java-api) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-distributed-local-java-api) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/core/keyple-distributed-remote-api.md
+++ b/content/components/core/keyple-distributed-remote-api.md
@@ -33,7 +33,7 @@ The third version number (x.y.**z**) only concerns updates of the public API doc
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-distributed-remote-java-api) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-distributed-remote-java-api) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/core/keyple-plugin-api.md
+++ b/content/components/core/keyple-plugin-api.md
@@ -34,7 +34,7 @@ The third version number (x.y.**z**) only concerns updates of the public API doc
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-plugin-java-api) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-plugin-java-api) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/core/keyple-service-lib.md
+++ b/content/components/core/keyple-service-lib.md
@@ -30,7 +30,7 @@ Therefore, it must be used only by application developers.
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-service-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-service-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/core/keyple-service-resource-lib.md
+++ b/content/components/core/keyple-service-resource-lib.md
@@ -30,7 +30,7 @@ Therefore, it can be used by developers of applications or card extensions.
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-service-resource-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-service-resource-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/core/keyple-util-lib.md
+++ b/content/components/core/keyple-util-lib.md
@@ -33,7 +33,7 @@ Since this library is used by all Keyple libraries, it is recommended to import 
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-util-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-util-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/distributed/keyple-distributed-local-lib.md
+++ b/content/components/distributed/keyple-distributed-local-lib.md
@@ -32,7 +32,7 @@ It is compatible with **Windows**, **Linux**, **macOS** and **Android** platform
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-distributed-local-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-distributed-local-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/distributed/keyple-distributed-network-lib.md
+++ b/content/components/distributed/keyple-distributed-network-lib.md
@@ -32,7 +32,7 @@ It is compatible with **Windows**, **Linux**, **macOS** and **Android** platform
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-distributed-network-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-distributed-network-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/distributed/keyple-distributed-remote-lib.md
+++ b/content/components/distributed/keyple-distributed-remote-lib.md
@@ -32,7 +32,7 @@ It is compatible with **Windows**, **Linux**, **macOS** and **Android** platform
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-distributed-remote-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-distributed-remote-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/overview/configuration-wizard.md
+++ b/content/components/overview/configuration-wizard.md
@@ -35,6 +35,10 @@ What type of Keyple component are you working on?
   >    <input type="checkbox" id="cardCalypsoLegacySam" onclick="javascript:updateAppDependencies(1, this);">
   >    <label for="cardCalypsoLegacySam">Calypso Legacy SAM (required for secure card transactions)</label>
   >  </div>
+  >  <div>
+  >    <input type="checkbox" id="cardCalypsoPki" onclick="javascript:updateAppDependencies(1, this);">
+  >    <label for="cardCalypsoPki">Calypso PKI (required for PKI card transactions)</label>
+  >  </div>
 
 - Which reader plugin do you want to use?
   >  <div>
@@ -222,6 +226,7 @@ implementation("org.eclipse.keyple:keyple-util-java-lib:{{% keyple-util-java-lib
 <span id="keyple-util-java-lib">implementation <span class="hljs-string">'org.eclipse.keyple:keyple-util-java-lib:{{% keyple-util-java-lib-version %}}'</span></span>
 <span id="keyple-card-calypso-java-lib">implementation <span class="hljs-string">'org.eclipse.keyple:keyple-card-calypso-java-lib:{{% keyple-card-calypso-java-lib-version %}}'</span></span>
 <span id="keyple-card-calypso-crypto-legacysam-java-lib">implementation <span class="hljs-string">'org.eclipse.keyple:keyple-card-calypso-crypto-legacysam-java-lib:{{% keyple-card-calypso-crypto-legacysam-java-lib-version %}}'</span></span>
+<span id="keyple-card-calypso-crypto-pki-java-lib">implementation <span class="hljs-string">'org.eclipse.keyple:keyple-card-calypso-crypto-pki-java-lib:{{% keyple-card-calypso-crypto-pki-java-lib-version %}}'</span></span>
 <span id="keyple-card-generic-java-lib">implementation <span class="hljs-string">'org.eclipse.keyple:keyple-card-generic-java-lib:{{% keyple-card-generic-java-lib-version %}}'</span></span>
 <span id="keyple-distributed-local-java-lib">implementation <span class="hljs-string">'org.eclipse.keyple:keyple-distributed-local-java-lib:{{% keyple-distributed-local-java-lib-version %}}'</span></span>
 <span id="keyple-distributed-network-java-lib">implementation <span class="hljs-string">'org.eclipse.keyple:keyple-distributed-network-java-lib:{{% keyple-distributed-network-java-lib-version %}}'</span></span>
@@ -245,6 +250,7 @@ implementation("org.eclipse.keyple:keyple-util-java-lib:{{% keyple-util-java-lib
 <span id="keyple-util-java-lib">implementation(<span class="hljs-string">"org.eclipse.keyple:keyple-util-java-lib:{{% keyple-util-java-lib-version %}}"</span>)</span>
 <span id="keyple-card-calypso-java-lib">implementation(<span class="hljs-string">"org.eclipse.keyple:keyple-card-calypso-java-lib:{{% keyple-card-calypso-java-lib-version %}}"</span>)</span>
 <span id="keyple-card-calypso-crypto-legacysam-java-lib">implementation(<span class="hljs-string">"org.eclipse.keyple:keyple-card-calypso-crypto-legacysam-java-lib:{{% keyple-card-calypso-crypto-legacysam-java-lib-version %}}"</span>)</span>
+<span id="keyple-card-calypso-crypto-pki-java-lib">implementation(<span class="hljs-string">"org.eclipse.keyple:keyple-card-calypso-crypto-pki-java-lib:{{% keyple-card-calypso-crypto-pki-java-lib-version %}}"</span>)</span>
 <span id="keyple-card-generic-java-lib">implementation(<span class="hljs-string">"org.eclipse.keyple:keyple-card-generic-java-lib:{{% keyple-card-generic-java-lib-version %}}"</span>)</span>
 <span id="keyple-distributed-local-java-lib">implementation(<span class="hljs-string">"org.eclipse.keyple:keyple-distributed-local-java-lib:{{% keyple-distributed-local-java-lib-version %}}"</span>)</span>
 <span id="keyple-distributed-network-java-lib">implementation(<span class="hljs-string">"org.eclipse.keyple:keyple-distributed-network-java-lib:{{% keyple-distributed-network-java-lib-version %}}"</span>)</span>
@@ -292,6 +298,11 @@ implementation("org.eclipse.keyple:keyple-util-java-lib:{{% keyple-util-java-lib
   <span class="hljs-tag">&lt;<span class="hljs-name">groupId</span>&gt;</span>org.eclipse.keyple<span class="hljs-tag">&lt;/<span class="hljs-name">groupId</span>&gt;</span>
   <span class="hljs-tag">&lt;<span class="hljs-name">artifactId</span>&gt;</span>keyple-card-calypso-crypto-legacysam-java-lib<span class="hljs-tag">&lt;/<span class="hljs-name">artifactId</span>&gt;</span>
   <span class="hljs-tag">&lt;<span class="hljs-name">version</span>&gt;</span>{{% keyple-card-calypso-crypto-legacysam-java-lib-version %}}<span class="hljs-tag">&lt;/<span class="hljs-name">version</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">dependency</span>&gt;</span></span>
+<span id="keyple-card-calypso-crypto-pki-java-lib"><span class="hljs-tag">&lt;<span class="hljs-name">dependency</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">groupId</span>&gt;</span>org.eclipse.keyple<span class="hljs-tag">&lt;/<span class="hljs-name">groupId</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">artifactId</span>&gt;</span>keyple-card-calypso-crypto-pki-java-lib<span class="hljs-tag">&lt;/<span class="hljs-name">artifactId</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">version</span>&gt;</span>{{% keyple-card-calypso-crypto-pki-java-lib-version %}}<span class="hljs-tag">&lt;/<span class="hljs-name">version</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">dependency</span>&gt;</span></span>
 <span id="keyple-card-generic-java-lib"><span class="hljs-tag">&lt;<span class="hljs-name">dependency</span>&gt;</span>
   <span class="hljs-tag">&lt;<span class="hljs-name">groupId</span>&gt;</span>org.eclipse.keyple<span class="hljs-tag">&lt;/<span class="hljs-name">groupId</span>&gt;</span>

--- a/content/components/overview/dependency-check.md
+++ b/content/components/overview/dependency-check.md
@@ -41,7 +41,7 @@ as they only concern documentation updates.
             <th colspan="4" class="bg-yellow">Core APIs</th>
             <th colspan="3" class="bg-blue">Core libraries</th>
             <th colspan="3" class="bg-purple">Distributed systems libraries</th>
-            <th colspan="3" class="bg-green">Card extensions libraries</th>
+            <th colspan="4" class="bg-green">Card extensions libraries</th>
             <th colspan="5" class="bg-red">Standard reader plugins libraries</th>
         </tr>
         <tr>
@@ -63,6 +63,7 @@ as they only concern documentation updates.
             <th class="bg-purple">Remote<br>Lib</th>
             <th class="bg-green">Calypso Card<br>Lib</th>
             <th class="bg-green">Calypso Legacy SAM<br>Lib</th>
+            <th class="bg-green">Calypso PKI<br>Lib</th>
             <th class="bg-green">Generic<br>Lib</th>
             <th class="bg-red">Android NFC<br>Lib</th>
             <th class="bg-red">Android OMAPI<br>Lib</th>

--- a/content/components/standard-reader-plugins/keyple-plugin-android-nfc-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-android-nfc-lib.md
@@ -31,7 +31,7 @@ It is compatible with **Android 4.4 minimum**.
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-plugin-android-nfc-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-plugin-android-nfc-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/standard-reader-plugins/keyple-plugin-android-omapi-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-android-omapi-lib.md
@@ -34,7 +34,7 @@ This allows the app to benefit from enhanced SE-based security services.
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-plugin-android-omapi-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-plugin-android-omapi-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/standard-reader-plugins/keyple-plugin-cardresource-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-cardresource-lib.md
@@ -41,7 +41,7 @@ inserted in a dedicated PC/SC reader.
 ### Download
 
 All deliverables are available directly from the 
-[Maven Central Repository](https://central.sonatype.dev/search?q=keyple-plugin-cardresource-java-lib) or by using one 
+[Maven Central Repository](https://central.sonatype.com/search?q=keyple-plugin-cardresource-java-lib) or by using one 
 of the project resource managers below:
 
 {{< tabpane >}}

--- a/content/components/standard-reader-plugins/keyple-plugin-pcsc-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-pcsc-lib.md
@@ -31,7 +31,7 @@ It is compatible with **PC/SC Reader** (Windows PC/SC WinScard API, Unix PC/SC l
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-plugin-pcsc-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-plugin-pcsc-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/components/standard-reader-plugins/keyple-plugin-stub-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-stub-lib.md
@@ -31,7 +31,7 @@ It is compatible with **Windows**, **Linux**, **macOS** and **Android** platform
 
 ### Download
 
-All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-plugin-stub-java-lib) or by using one of the project resource managers below:
+All deliverables are available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-plugin-stub-java-lib) or by using one of the project resource managers below:
 
 {{< tabpane >}}
 {{< tab header="Gradle Groovy" lang="gradle" >}}

--- a/content/learn/keyple-in-depth/build-and-ci.md
+++ b/content/learn/keyple-in-depth/build-and-ci.md
@@ -29,7 +29,7 @@ For API components (i.e. artifacts suffixed with `-api`), the incrementation of 
 
 Keyple continuous integration works with the [Jenkins server](https://ci.eclipse.org/keyple/job/Keyple/) of the Eclipse Foundation.
 
-The build process uses the home-made gradle plugin **Keyple Gradle** available directly from the [Maven Central Repository](https://central.sonatype.dev/search?q=keyple-gradle) and whose sources are available on [GitHub](https://github.com/eclipse-keyple/keyple-ops).
+The build process uses the home-made gradle plugin **Keyple Gradle** available directly from the [Maven Central Repository](https://central.sonatype.com/search?q=keyple-gradle) and whose sources are available on [GitHub](https://github.com/eclipse-keyple/keyple-ops).
 
 The CI automates the following tasks (defined in the `Jenkinsfile` file):
 * verify the validity of the version;

--- a/layouts/shortcodes/keyple-card-calypso-crypto-pki-java-lib-version.html
+++ b/layouts/shortcodes/keyple-card-calypso-crypto-pki-java-lib-version.html
@@ -1,0 +1,1 @@
+{{ $.Site.Params.keyple_version.keyple_card_calypso_crypto_pki_java_lib }}


### PR DESCRIPTION
- keypop_calypso_crypto_legacysam_java_api: '0.6.0'
- keyple_card_calypso_crypto_legacysam_java_lib: '0.7.0'
- keyple_card_calypso_crypto_pki_java_lib: '0.2.0'