### PR TITLE
docs: update API documentation links to docs.keyple.org

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -748,7 +748,7 @@ loadProjectDashboard = async function() {
             case "error":
             case "failure":
                 a.style.color = "red";
-                a.title += ": failure";gi
+                a.title += ": failure";
                 break;
             case "pending":
                 a.style.color = "orange";

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -593,7 +593,7 @@ loadProjectDashboard = async function() {
             cell.appendChild(space);
             a.innerHTML = "<i class=\"fas fa-book\"></i>";
             a.title = "API documentation for " + json.name;
-            a.href = "https://eclipse-keyple.github.io/" + json.name;
+            a.href = "https://docs.keyple.org/" + json.name;
             a.target = "_blank";
             cell.appendChild(a);
         }
@@ -748,7 +748,7 @@ loadProjectDashboard = async function() {
             case "error":
             case "failure":
                 a.style.color = "red";
-                a.title += ": failure";
+                a.title += ": failure";gi
                 break;
             case "pending":
                 a.style.color = "orange";

--- a/content/components/card-extensions/keyple-card-calypso-crypto-legacysam-lib.md
+++ b/content/components/card-extensions/keyple-card-calypso-crypto-legacysam-lib.md
@@ -31,7 +31,7 @@ Therefore, it should be used only by application developers.
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-card-calypso-crypto-legacysam-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-card-calypso-crypto-legacysam-java-lib)
 
 ### Download
 

--- a/content/components/card-extensions/keyple-card-calypso-crypto-pki-lib.md
+++ b/content/components/card-extensions/keyple-card-calypso-crypto-pki-lib.md
@@ -30,7 +30,7 @@ Therefore, it should be used only by application developers.
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-card-calypso-crypto-pki-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-card-calypso-crypto-pki-java-lib)
 
 ### Download
 

--- a/content/components/card-extensions/keyple-card-calypso-lib.md
+++ b/content/components/card-extensions/keyple-card-calypso-lib.md
@@ -31,7 +31,7 @@ At present, only the [Calypso Crypto Legacy SAM]({{< relref "keyple-card-calypso
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-card-calypso-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-card-calypso-java-lib)
 * [User guide]({{< relref "/learn/user-guide/calypso-application" >}})
 
 ### Download

--- a/content/components/card-extensions/keyple-card-generic-lib.md
+++ b/content/components/card-extensions/keyple-card-generic-lib.md
@@ -25,7 +25,7 @@ Therefore, it should be used only by application developers.
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-card-generic-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-card-generic-java-lib)
 
 ### Download
 

--- a/content/components/core/keyple-common-api.md
+++ b/content/components/core/keyple-common-api.md
@@ -29,7 +29,7 @@ The third version number (x.y.**z**) only concerns updates of the public API doc
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-common-java-api)
+* [API documentation](https://docs.keyple.org/keyple-common-java-api)
 * [User guide]({{< relref "/learn/user-guide/standalone-application" >}})
  
 ### Download

--- a/content/components/core/keyple-distributed-local-api.md
+++ b/content/components/core/keyple-distributed-local-api.md
@@ -29,7 +29,7 @@ The third version number (x.y.**z**) only concerns updates of the public API doc
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-distributed-local-java-api)
+* [API documentation](https://docs.keyple.org/keyple-distributed-local-java-api)
 
 ### Download
 

--- a/content/components/core/keyple-distributed-remote-api.md
+++ b/content/components/core/keyple-distributed-remote-api.md
@@ -29,7 +29,7 @@ The third version number (x.y.**z**) only concerns updates of the public API doc
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-distributed-remote-java-api)
+* [API documentation](https://docs.keyple.org/keyple-distributed-remote-java-api)
 
 ### Download
 

--- a/content/components/core/keyple-plugin-api.md
+++ b/content/components/core/keyple-plugin-api.md
@@ -29,7 +29,7 @@ The third version number (x.y.**z**) only concerns updates of the public API doc
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-plugin-java-api)
+* [API documentation](https://docs.keyple.org/keyple-plugin-java-api)
 * [Developer guide]({{< relref "/learn/developer-guide/reader-plugin-add-on" >}})
 
 ### Download

--- a/content/components/core/keyple-service-lib.md
+++ b/content/components/core/keyple-service-lib.md
@@ -25,7 +25,7 @@ Therefore, it must be used only by application developers.
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-service-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-service-java-lib)
 * [User guide]({{< relref "/learn/user-guide/standalone-application" >}})
 
 ### Download

--- a/content/components/core/keyple-service-resource-lib.md
+++ b/content/components/core/keyple-service-resource-lib.md
@@ -25,7 +25,7 @@ Therefore, it can be used by developers of applications or card extensions.
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-service-resource-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-service-resource-java-lib)
 * [User guide]({{< relref "/learn/user-guide/card-resource-service" >}})
 
 ### Download

--- a/content/components/core/keyple-util-lib.md
+++ b/content/components/core/keyple-util-lib.md
@@ -29,7 +29,7 @@ Since this library is used by all Keyple libraries, it is recommended to import 
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-util-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-util-java-lib)
 
 ### Download
 

--- a/content/components/distributed/keyple-distributed-local-lib.md
+++ b/content/components/distributed/keyple-distributed-local-lib.md
@@ -27,7 +27,7 @@ It is compatible with **Windows**, **Linux**, **macOS** and **Android** platform
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-distributed-local-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-distributed-local-java-lib)
 * [User guide]({{< relref "/learn/user-guide/distributed-application" >}})
 
 ### Download

--- a/content/components/distributed/keyple-distributed-network-lib.md
+++ b/content/components/distributed/keyple-distributed-network-lib.md
@@ -27,7 +27,7 @@ It is compatible with **Windows**, **Linux**, **macOS** and **Android** platform
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-distributed-network-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-distributed-network-java-lib)
 * [User guide]({{< relref "/learn/user-guide/distributed-application" >}})
 
 ### Download

--- a/content/components/distributed/keyple-distributed-remote-lib.md
+++ b/content/components/distributed/keyple-distributed-remote-lib.md
@@ -27,7 +27,7 @@ It is compatible with **Windows**, **Linux**, **macOS** and **Android** platform
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-distributed-remote-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-distributed-remote-java-lib)
 * [User guide]({{< relref "/learn/user-guide/distributed-application" >}})
 
 ### Download

--- a/content/components/standard-reader-plugins/keyple-plugin-android-nfc-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-android-nfc-lib.md
@@ -27,7 +27,7 @@ It is compatible with **Android 4.4 minimum**.
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-plugin-android-nfc-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-plugin-android-nfc-java-lib)
 
 ### Download
 

--- a/content/components/standard-reader-plugins/keyple-plugin-android-omapi-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-android-omapi-lib.md
@@ -30,7 +30,7 @@ This allows the app to benefit from enhanced SE-based security services.
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-plugin-android-omapi-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-plugin-android-omapi-java-lib)
 
 ### Download
 

--- a/content/components/standard-reader-plugins/keyple-plugin-cardresource-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-cardresource-lib.md
@@ -36,7 +36,7 @@ inserted in a dedicated PC/SC reader.
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-plugin-cardresource-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-plugin-cardresource-java-lib)
 
 ### Download
 

--- a/content/components/standard-reader-plugins/keyple-plugin-pcsc-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-pcsc-lib.md
@@ -27,7 +27,7 @@ It is compatible with **PC/SC Reader** (Windows PC/SC WinScard API, Unix PC/SC l
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-plugin-pcsc-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-plugin-pcsc-java-lib)
 
 ### Download
 

--- a/content/components/standard-reader-plugins/keyple-plugin-stub-lib.md
+++ b/content/components/standard-reader-plugins/keyple-plugin-stub-lib.md
@@ -27,7 +27,7 @@ It is compatible with **Windows**, **Linux**, **macOS** and **Android** platform
 
 ### Documentation
 
-* [API documentation](https://eclipse-keyple.github.io/keyple-plugin-stub-java-lib)
+* [API documentation](https://docs.keyple.org/keyple-plugin-stub-java-lib)
 
 ### Download
 

--- a/content/learn/developer-guide/card-extension-add-on.md
+++ b/content/learn/developer-guide/card-extension-add-on.md
@@ -141,7 +141,7 @@ For this purpose, it is suggested to respect the following programming pattern b
 
 ## API
 
-* [Keyple Common API](https://eclipse-keyple.github.io/keyple-common-java-api)
+* [Keyple Common API](https://docs.keyple.org/keyple-common-java-api)
 * [Keypop Reader API](https://keypop.org/apis/reader-layer/reader-api/)
 * [Keypop Card API](https://keypop.org/apis/reader-layer/card-api/)
 

--- a/content/learn/developer-guide/reader-plugin-add-on.md
+++ b/content/learn/developer-guide/reader-plugin-add-on.md
@@ -111,8 +111,8 @@ Thus, the factory does not expose any method.
 
 ## API
 
-* [Keyple Common API](https://eclipse-keyple.github.io/keyple-common-java-api)
-* [Keyple Plugin API](https://eclipse-keyple.github.io/keyple-plugin-java-api)
+* [Keyple Common API](https://docs.keyple.org/keyple-common-java-api)
+* [Keyple Plugin API](https://docs.keyple.org/keyple-plugin-java-api)
 
 <br>
 

--- a/content/learn/user-guide/calypso-application.md
+++ b/content/learn/user-guide/calypso-application.md
@@ -194,9 +194,9 @@ calypsoCardApiFactory
 * [Keypop Reader API](https://keypop.org/apis/reader-layer/reader-api/)
 * [Keypop Calypso Card API](https://keypop.org/apis/calypso-layer/calypso-card-api/)
 * [Keypop Calypso Crypto Legacy SAM API](https://keypop.org/apis/calypso-layer/calypso-legacysam-api/)
-* [Keyple Common API](https://eclipse-keyple.github.io/keyple-common-java-api)
-* [Keyple Card Calypso API](https://eclipse-keyple.github.io/keyple-card-calypso-java-lib)
-* [Keyple Card Calypso Crypto Legacy SAM API](https://eclipse-keyple.github.io/keyple-card-calypso-crypto-legacysam-java-lib)
+* [Keyple Common API](https://docs.keyple.org/keyple-common-java-api)
+* [Keyple Card Calypso API](https://docs.keyple.org/keyple-card-calypso-java-lib)
+* [Keyple Card Calypso Crypto Legacy SAM API](https://docs.keyple.org/keyple-card-calypso-crypto-legacysam-java-lib)
 
 <br>
 

--- a/content/learn/user-guide/card-resource-service.md
+++ b/content/learn/user-guide/card-resource-service.md
@@ -253,7 +253,7 @@ cardResourceService.stop();
 
 ## API
 
-* [API documentation & class diagram](https://eclipse-keyple.github.io/keyple-service-resource-java-lib)
+* [API documentation & class diagram](https://docs.keyple.org/keyple-service-resource-java-lib)
 
 <br>
 

--- a/content/learn/user-guide/distributed-application.md
+++ b/content/learn/user-guide/distributed-application.md
@@ -297,9 +297,9 @@ However, it is necessary in some contexts to access certain information such as 
 
 ## API
 
-* [Local API](https://eclipse-keyple.github.io/keyple-distributed-local-java-lib)
-* [Network API](https://eclipse-keyple.github.io/keyple-distributed-network-java-lib)
-* [Remote API](https://eclipse-keyple.github.io/keyple-distributed-remote-java-lib)
+* [Local API](https://docs.keyple.org/keyple-distributed-local-java-lib)
+* [Network API](https://docs.keyple.org/keyple-distributed-network-java-lib)
+* [Remote API](https://docs.keyple.org/keyple-distributed-remote-java-lib)
 
 <br>
 

--- a/content/learn/user-guide/standalone-application.md
+++ b/content/learn/user-guide/standalone-application.md
@@ -439,8 +439,8 @@ smartCardService.unregisterPlugin(plugin.getName());
 ## API
 
 * [Keypop Reader API](https://keypop.org/apis/reader-layer/reader-api/)
-* [Keyple Common API](https://eclipse-keyple.github.io/keyple-common-java-api)
-* [Keyple Service API](https://eclipse-keyple.github.io/keyple-service-java-lib)
+* [Keyple Common API](https://docs.keyple.org/keyple-common-java-api)
+* [Keyple Service API](https://docs.keyple.org/keyple-service-java-lib)
 
 <br>
 


### PR DESCRIPTION
Replaced old API documentation URLs with updated links to docs.keyple.org across multiple documentation files. This ensures consistency and accessibility of API documentation.